### PR TITLE
Change "light_blue" and "silver" dye names to correct minecraft conventions

### DIFF
--- a/src/main/java/com/bioxx/tfc/Items/ItemDyeCustom.java
+++ b/src/main/java/com/bioxx/tfc/Items/ItemDyeCustom.java
@@ -27,7 +27,7 @@ public class ItemDyeCustom extends ItemTerra {
 
     /** List of dye color names */
     public static final String[] DYE_COLOR_NAMES = new String[] { "black", "red", "green", "brown", "blue", "purple",
-        "cyan", "silver", "gray", "pink", "lime", "yellow", "light_blue", "magenta", "orange", "white" };
+        "cyan", "lightGray", "gray", "pink", "lime", "yellow", "lightBlue", "magenta", "orange", "white" };
     public static final int[] DYE_COLORS = new int[] { 1973019, 11743532, 3887386, 5320730, 2437522, 8073150, 2651799,
         2651799, 4408131, 14188952, 4312372, 14602026, 6719955, 12801229, 15435844, 15790320 };
     @SideOnly(Side.CLIENT)

--- a/src/main/java/com/bioxx/tfc/Items/ItemDyeCustom.java
+++ b/src/main/java/com/bioxx/tfc/Items/ItemDyeCustom.java
@@ -28,6 +28,8 @@ public class ItemDyeCustom extends ItemTerra {
     /** List of dye color names */
     public static final String[] DYE_COLOR_NAMES = new String[] { "black", "red", "green", "brown", "blue", "purple",
         "cyan", "lightGray", "gray", "pink", "lime", "yellow", "lightBlue", "magenta", "orange", "white" };
+    public static final String[] DYE_COLOR_ICONS = new String[] { "black", "red", "green", "brown", "blue", "purple",
+        "cyan", "silver", "gray", "pink", "lime", "yellow", "light_blue", "magenta", "orange", "white" };
     public static final int[] DYE_COLORS = new int[] { 1973019, 11743532, 3887386, 5320730, 2437522, 8073150, 2651799,
         2651799, 4408131, 14188952, 4312372, 14602026, 6719955, 12801229, 15435844, 15790320 };
     @SideOnly(Side.CLIENT)
@@ -67,7 +69,7 @@ public class ItemDyeCustom extends ItemTerra {
         this.icons = new IIcon[DYE_COLOR_NAMES.length];
 
         for (int i = 0; i < DYE_COLOR_NAMES.length; ++i) {
-            this.icons[i] = par1IconRegister.registerIcon(this.getIconString() + "_" + DYE_COLOR_NAMES[i]);
+            this.icons[i] = par1IconRegister.registerIcon(this.getIconString() + "_" + DYE_COLOR_ICONS[i]);
         }
     }
 

--- a/src/main/resources/assets/terrafirmacraft/lang/da_DK.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/da_DK.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Orange Farve
 item.dyePowder.pink.name=Lyserød Farve
 item.dyePowder.purple.name=Lilla Farve
 item.dyePowder.red.name=Rød Farve
-item.dyePowder.silver.name=Lysegrå Farve
+item.dyePowder.lightGray.name=Lysegrå Farve
 item.dyePowder.white.name=Benmel
 item.dyePowder.yellow.name=Gul Farve
 

--- a/src/main/resources/assets/terrafirmacraft/lang/de_DE.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/de_DE.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Orange
 item.dyePowder.pink.name=Pink
 item.dyePowder.purple.name=Violett
 item.dyePowder.red.name=Rosenrot
-item.dyePowder.silver.name=Silber
+item.dyePowder.lightGray.name=Silber
 item.dyePowder.white.name=Knochenmehl
 item.dyePowder.yellow.name=Löwenzahngelb
 

--- a/src/main/resources/assets/terrafirmacraft/lang/en_CA.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/en_CA.lang
@@ -5,7 +5,7 @@
 #= Powders =
 #===========
 item.dyePowder.gray.name=Grey Dye
-item.dyePowder.silver.name=Light Grey Dye
+item.dyePowder.lightGray.name=Light Grey Dye
 
 item.Powder.Sulfur Powder.name=Sulphur Powder
 

--- a/src/main/resources/assets/terrafirmacraft/lang/en_GB.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/en_GB.lang
@@ -102,7 +102,7 @@ item.Sword Mold.Ceramic Mold Sword Bismuth Bronze.name=Sword Mould (Bismuth Bron
 #= Powders =
 #===========
 item.dyePowder.gray.name=Grey Dye
-item.dyePowder.silver.name=Light Grey Dye
+item.dyePowder.lightGray.name=Light Grey Dye
 
 item.Powder.Saltpeter Powder.name=Saltpetre Powder
 item.Powder.Sulfur Powder.name=Sulphur Powder

--- a/src/main/resources/assets/terrafirmacraft/lang/en_US.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/en_US.lang
@@ -606,7 +606,7 @@ item.dyePowder.orange.name=Orange Dye
 item.dyePowder.pink.name=Pink Dye
 item.dyePowder.purple.name=Purple Dye
 item.dyePowder.red.name=Red Dye
-item.dyePowder.silver.name=Light Gray Dye
+item.dyePowder.lightGray.name=Light Gray Dye
 item.dyePowder.white.name=Bone Meal
 item.dyePowder.yellow.name=Yellow Dye
 

--- a/src/main/resources/assets/terrafirmacraft/lang/es_AR.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/es_AR.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Tinte Naranja
 item.dyePowder.pink.name=Tinte Rosa
 item.dyePowder.purple.name=Tinte Purpura
 item.dyePowder.red.name=Rosa Roja
-item.dyePowder.silver.name=Tinte Plateado
+item.dyePowder.lightGray.name=Tinte Plateado
 item.dyePowder.white.name=Polvo de Hueso
 item.dyePowder.yellow.name=Tinte Amarillo
 

--- a/src/main/resources/assets/terrafirmacraft/lang/es_ES.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/es_ES.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Tinte Naranja
 item.dyePowder.pink.name=Tinte Rosa
 item.dyePowder.purple.name=Tinte Purpura
 item.dyePowder.red.name=Rosa Roja
-item.dyePowder.silver.name=Tinte Plateado
+item.dyePowder.lightGray.name=Tinte Plateado
 item.dyePowder.white.name=Polvo de Hueso
 item.dyePowder.yellow.name=Tinte Amarillo
 

--- a/src/main/resources/assets/terrafirmacraft/lang/es_MX.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/es_MX.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Tinte Naranja
 item.dyePowder.pink.name=Tinte Rosa
 item.dyePowder.purple.name=Tinte Purpura
 item.dyePowder.red.name=Rosa Roja
-item.dyePowder.silver.name=Tinte Plateado
+item.dyePowder.lightGray.name=Tinte Plateado
 item.dyePowder.white.name=Polvo de Hueso
 item.dyePowder.yellow.name=Tinte Amarillo
 

--- a/src/main/resources/assets/terrafirmacraft/lang/es_UY.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/es_UY.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Tinte Naranja
 item.dyePowder.pink.name=Tinte Rosa
 item.dyePowder.purple.name=Tinte Purpura
 item.dyePowder.red.name=Rosa Roja
-item.dyePowder.silver.name=Tinte Plateado
+item.dyePowder.lightGray.name=Tinte Plateado
 item.dyePowder.white.name=Polvo de Hueso
 item.dyePowder.yellow.name=Tinte Amarillo
 

--- a/src/main/resources/assets/terrafirmacraft/lang/es_VE.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/es_VE.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Tinte Naranja
 item.dyePowder.pink.name=Tinte Rosa
 item.dyePowder.purple.name=Tinte Purpura
 item.dyePowder.red.name=Rosa Roja
-item.dyePowder.silver.name=Tinte Plateado
+item.dyePowder.lightGray.name=Tinte Plateado
 item.dyePowder.white.name=Polvo de Hueso
 item.dyePowder.yellow.name=Tinte Amarillo
 

--- a/src/main/resources/assets/terrafirmacraft/lang/fi_FI.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/fi_FI.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Oranssi väriaine
 item.dyePowder.pink.name=Pinkki väriaine
 item.dyePowder.purple.name=Purppura väriaine
 item.dyePowder.red.name=Ruusunpunainen väriaine
-item.dyePowder.silver.name=Vaaleanharmaa väriaine
+item.dyePowder.lightGray.name=Vaaleanharmaa väriaine
 item.dyePowder.white.name=Luujauho
 item.dyePowder.yellow.name=Voikukankeltainen väriaine
 

--- a/src/main/resources/assets/terrafirmacraft/lang/fr_CA.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/fr_CA.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Teinture orange
 item.dyePowder.pink.name=Teinture rose
 item.dyePowder.purple.name=Teinture mauve
 item.dyePowder.red.name=Teinture rouge
-item.dyePowder.silver.name=Teinture gris pâle
+item.dyePowder.lightGray.name=Teinture gris pâle
 item.dyePowder.white.name=Poudre d'os
 item.dyePowder.yellow.name=Teinture jaune
 

--- a/src/main/resources/assets/terrafirmacraft/lang/fr_FR.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/fr_FR.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Teinture orange
 item.dyePowder.pink.name=Teinture rose
 item.dyePowder.purple.name=Teinture mauve
 item.dyePowder.red.name=Teinture rouge
-item.dyePowder.silver.name=Teinture gris pâle
+item.dyePowder.lightGray.name=Teinture gris pâle
 item.dyePowder.white.name=Poudre d'os
 item.dyePowder.yellow.name=Teinture jaune
 

--- a/src/main/resources/assets/terrafirmacraft/lang/hu_HU.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/hu_HU.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Narancssárga festék
 item.dyePowder.pink.name=Rózsaszín festék
 item.dyePowder.purple.name=Lila festék
 item.dyePowder.red.name=Piros festék
-item.dyePowder.silver.name=Világosszürke festék
+item.dyePowder.lightGray.name=Világosszürke festék
 item.dyePowder.white.name=Csontliszt
 item.dyePowder.yellow.name=Sárga festék
 

--- a/src/main/resources/assets/terrafirmacraft/lang/it_IT.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/it_IT.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Tintura arancione
 item.dyePowder.pink.name=Tintura rosa
 item.dyePowder.purple.name=Tintura viola
 item.dyePowder.red.name=Tintura rossa
-item.dyePowder.silver.name=Tintura argento
+item.dyePowder.lightGray.name=Tintura argento
 item.dyePowder.white.name=Farina d'ossa
 item.dyePowder.yellow.name=Tintura gialla
 

--- a/src/main/resources/assets/terrafirmacraft/lang/ja_JP.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/ja_JP.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=橙色の染料
 item.dyePowder.pink.name=桃色の染料
 item.dyePowder.purple.name=紫色の染料
 item.dyePowder.red.name=赤色の染料
-item.dyePowder.silver.name=薄灰色の染料
+item.dyePowder.lightGray.name=薄灰色の染料
 item.dyePowder.white.name=骨粉
 item.dyePowder.yellow.name=黄色の染料
 

--- a/src/main/resources/assets/terrafirmacraft/lang/ko_KR.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/ko_KR.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=주황색 염료
 item.dyePowder.pink.name=분홍색 염료
 item.dyePowder.purple.name=보라색 염료
 item.dyePowder.red.name=붉은색 염료
-item.dyePowder.silver.name=밝은 회색 염료
+item.dyePowder.lightGray.name=밝은 회색 염료
 item.dyePowder.white.name=뼛가루
 item.dyePowder.yellow.name=노란색 염료
 

--- a/src/main/resources/assets/terrafirmacraft/lang/nl_NL.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/nl_NL.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Oranje Kleurstof
 item.dyePowder.pink.name=Roze Kleurstof
 item.dyePowder.purple.name=Paarse Kleurstof
 item.dyePowder.red.name=Rode Kleurstof
-item.dyePowder.silver.name=Zilvere Kleurstof
+item.dyePowder.lightGray.name=Zilvere Kleurstof
 item.dyePowder.white.name=Witte Kleurstof
 item.dyePowder.yellow.name=Gele Kleurstof
 

--- a/src/main/resources/assets/terrafirmacraft/lang/pt_BR.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/pt_BR.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Corante Laranja
 item.dyePowder.pink.name=Corante Rosa
 item.dyePowder.purple.name=Corante Lilás
 item.dyePowder.red.name=Corante Vermelho
-item.dyePowder.silver.name=Corante Cinza Claro
+item.dyePowder.lightGray.name=Corante Cinza Claro
 item.dyePowder.white.name=Farinha de Osso
 item.dyePowder.yellow.name=Corante Amarelo
 

--- a/src/main/resources/assets/terrafirmacraft/lang/pt_PT.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/pt_PT.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Corante Laranja
 item.dyePowder.pink.name=Corante Rosa
 item.dyePowder.purple.name=Corante Roxo
 item.dyePowder.red.name=Corante Vermelho
-item.dyePowder.silver.name=Corante Prateado
+item.dyePowder.lightGray.name=Corante Prateado
 item.dyePowder.white.name=Farinha de Osso
 item.dyePowder.yellow.name=Corante Amarelo
 

--- a/src/main/resources/assets/terrafirmacraft/lang/ro_RO.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/ro_RO.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Vopsea portocalie
 item.dyePowder.pink.name=Vopsea roz
 item.dyePowder.purple.name=Vopsea violetă
 item.dyePowder.red.name=Vopsea roșie
-item.dyePowder.silver.name=Vopsea gri-deschis
+item.dyePowder.lightGray.name=Vopsea gri-deschis
 item.dyePowder.white.name=Făină de oase
 item.dyePowder.yellow.name=Vopsea galbenă
 

--- a/src/main/resources/assets/terrafirmacraft/lang/ru_RU.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/ru_RU.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Оранжевый краситель
 item.dyePowder.pink.name=Розовый краситель
 item.dyePowder.purple.name=Фиолетовый краситель
 item.dyePowder.red.name=Цвет розы
-item.dyePowder.silver.name=Серебряный краситель
+item.dyePowder.lightGray.name=Серебряный краситель
 item.dyePowder.white.name=Костяной порошок
 item.dyePowder.yellow.name=Одуванчиковый жёлтый
 

--- a/src/main/resources/assets/terrafirmacraft/lang/tr_TR.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/tr_TR.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=Turuncu Boya
 item.dyePowder.pink.name=Pembe Boya
 item.dyePowder.purple.name=Mor Boya
 item.dyePowder.red.name=Kırmızı Boya
-item.dyePowder.silver.name=Açık Gri Boya
+item.dyePowder.lightGray.name=Açık Gri Boya
 item.dyePowder.white.name=Kemik Tozu
 item.dyePowder.yellow.name=Sarı Boya
 

--- a/src/main/resources/assets/terrafirmacraft/lang/zh_CN.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/zh_CN.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=橙色颜料
 item.dyePowder.pink.name=粉色颜料
 item.dyePowder.purple.name=紫色颜料
 item.dyePowder.red.name=红色颜料
-item.dyePowder.silver.name=浅灰色颜料
+item.dyePowder.lightGray.name=浅灰色颜料
 item.dyePowder.white.name=骨粉
 item.dyePowder.yellow.name=黄色颜料
 

--- a/src/main/resources/assets/terrafirmacraft/lang/zh_HK.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/zh_HK.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=橙染料(Orange Dye)
 item.dyePowder.pink.name=粉紅染料(Pink Dye)
 item.dyePowder.purple.name=紫染料(Purple Dye)
 item.dyePowder.red.name=紅染料(Red Dye)
-item.dyePowder.silver.name=淺灰染料(Light Gray Dye)
+item.dyePowder.lightGray.name=淺灰染料(Light Gray Dye)
 item.dyePowder.white.name=骨粉(Bone Meal)
 item.dyePowder.yellow.name=黃染料(Yellow Dye)
 

--- a/src/main/resources/assets/terrafirmacraft/lang/zh_TW.lang
+++ b/src/main/resources/assets/terrafirmacraft/lang/zh_TW.lang
@@ -512,7 +512,7 @@ item.dyePowder.orange.name=橙色染料
 item.dyePowder.pink.name=粉紅色染料
 item.dyePowder.purple.name=紫色染料
 item.dyePowder.red.name=紅色染料
-item.dyePowder.silver.name=淺灰色染料
+item.dyePowder.lightGray.name=淺灰色染料
 item.dyePowder.white.name=骨粉
 item.dyePowder.yellow.name=黃色染料
 


### PR DESCRIPTION
This *should* fix varied ore dictionary issues with silver and light blue lime paint from TFCTech, which relies on the data in TFC that I'm changing.